### PR TITLE
Auto detect entrypoint DLL for .Net Core application

### DIFF
--- a/1.0.4-runtime/init_container.sh
+++ b/1.0.4-runtime/init_container.sh
@@ -4,10 +4,16 @@ mkdir -p /home/LogFiles
 touch /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
 echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
 
-if [ $# -eq 0 ]
-  then
-    cd /defaulthome/hostingstart
-    exec dotnet hostingstart.dll
-  else
-    exec "$@"
+[ $# -ne 0 ] && exec "$@"
+
+CSPROJ=`ls -1 /home/site/repository/*.csproj 2>/dev/null | head -1`
+
+if [ -n "$CSPROJ" ]; then
+  DLL=./`basename "$CSPROJ" .csproj`.dll
+  echo Found: $DLL
+  [ -e "$DLL" ] && exec dotnet "$DLL"
 fi
+
+echo Could not find .csproj or .dll. Using default.
+cd /defaulthome/hostingstart
+exec dotnet hostingstart.dll

--- a/1.0.4-runtime/init_container.sh
+++ b/1.0.4-runtime/init_container.sh
@@ -2,12 +2,15 @@
 service ssh start
 mkdir -p /home/LogFiles
 touch /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
-echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
+echo "$(date) Container started" >> /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
 
+# If there is any command line argument specified, run it
 [ $# -ne 0 ] && exec "$@"
 
+# Pick up one .csproj file from repository where git push puts files into
 CSPROJ=`ls -1 /home/site/repository/*.csproj 2>/dev/null | head -1`
 
+# Convert /home/site/repository/<name>.csproj into ./<name>.dll and execute it
 if [ -n "$CSPROJ" ]; then
   DLL=./`basename "$CSPROJ" .csproj`.dll
   echo Found: $DLL

--- a/1.1.1-runtime/init_container.sh
+++ b/1.1.1-runtime/init_container.sh
@@ -4,10 +4,16 @@ mkdir -p /home/LogFiles
 touch /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
 echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
 
-if [ $# -eq 0 ]
-  then
-    cd /defaulthome/hostingstart
-    exec dotnet hostingstart.dll
-  else
-    exec "$@"
+[ $# -ne 0 ] && exec "$@"
+
+CSPROJ=`ls -1 /home/site/repository/*.csproj 2>/dev/null | head -1`
+
+if [ -n "$CSPROJ" ]; then
+  DLL=./`basename "$CSPROJ" .csproj`.dll
+  echo Found: $DLL
+  [ -e "$DLL" ] && exec dotnet "$DLL"
 fi
+
+echo Could not find .csproj or .dll. Using default.
+cd /defaulthome/hostingstart
+exec dotnet hostingstart.dll

--- a/1.1.1-runtime/init_container.sh
+++ b/1.1.1-runtime/init_container.sh
@@ -2,12 +2,15 @@
 service ssh start
 mkdir -p /home/LogFiles
 touch /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
-echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
+echo "$(date) Container started" >> /home/LogFiles/dotnet_$WEBSITE_ROLE_INSTANCE_ID_out.log
 
+# If there is any command line argument specified, run it
 [ $# -ne 0 ] && exec "$@"
 
+# Pick up one .csproj file from repository where git push puts files into
 CSPROJ=`ls -1 /home/site/repository/*.csproj 2>/dev/null | head -1`
 
+# Convert /home/site/repository/<name>.csproj into ./<name>.dll and execute it
 if [ -n "$CSPROJ" ]; then
   DLL=./`basename "$CSPROJ" .csproj`.dll
   echo Found: $DLL


### PR DESCRIPTION
This change will simplify how to set up .Net Core apps on App Service on Linux. Without this change, customer needs to manually set the App Command Line to something like "dotnet ./helloworld.dll".
The logic is to search a .csproj file in /home/site/deployment where git push puts files into and replace .csproj with .dll to generate the DLL name. If such DLL exists (i.e. dotnet has successfully built and published the DLL) to /home/site/wwwroot, then it will be launched without specifying anything in the App Command Line.
